### PR TITLE
Adaptación a Español basada en Rails

### DIFF
--- a/src/locale/es-ES.js
+++ b/src/locale/es-ES.js
@@ -1,0 +1,27 @@
+angular.module('platanus.inflector')
+/**
+ * es-CL rules by Francisco Arévalo
+ */
+.config(['inflectorProvider', function (inflectorProvider) {
+  inflectorProvider.registerLocale('es-CL', {
+    uncountable: ['tórax', 'tenis', 'fénix' ],
+    plural: [
+      [new RegExp('^(japon|escoc|ingl|dinamarqu|fregu|portugu)(es)', 'gi'), '$1eses'],
+      [new RegExp('(z)$', 'gi'),                                            '$1ces],
+      [new RegExp('(r)$', 'gi'),                                            '$1es'],
+      [new RegExp('([^aeéiou])$', 'gi'),                                    '$1es'],
+      [new RegExp('^(paí)s$', 'gi'),                                        '$1ses'],
+      [new RegExp('s$', 'gi'),                                              's'],
+      [new RegExp('$', 'gi'),                                               's']
+    ],
+
+    singular: [
+      [new RegExp('^(á|gá|paí)ses$', 'gi'),                                 '$1s'],
+      [new RegExp('(japon|escoc|ingl|dinamarqu|fregu|portugu)eses$', 'gi'), '$1es'],
+      [new RegExp('^(g|)ases$', 'gi'),                                      '$1as'],
+      [new RegExp('(ces)$', 'gi'),                                          'z'],
+      [new RegExp('es$', 'gi'),                                             ''],
+      [new RegExp('s$', 'gi'),                                              '']
+    ]
+  });
+}]);

--- a/src/locale/es-ES.js
+++ b/src/locale/es-ES.js
@@ -7,7 +7,7 @@ angular.module('platanus.inflector')
     uncountable: ['tórax', 'tenis', 'fénix' ],
     plural: [
       [new RegExp('^(japon|escoc|ingl|dinamarqu|fregu|portugu)(es)', 'gi'), '$1eses'],
-      [new RegExp('(z)$', 'gi'),                                            '$1ces],
+      [new RegExp('(z)$', 'gi'),                                            '$1ces'],
       [new RegExp('(r)$', 'gi'),                                            '$1es'],
       [new RegExp('([^aeéiou])$', 'gi'),                                    '$1es'],
       [new RegExp('^(paí)s$', 'gi'),                                        '$1ses'],


### PR DESCRIPTION
Adapté el archivo pt-BR.js basándome en el commit:
[](https://github.com/rails/rails/commit/7db0b073fec6bc3e6f213b58c76e7f43fcc2ab97)
Que parece funcionar bastante bien para algunos casos básicos:
```
   provider.setLocale('es-ES');
   inflector.pluralize('luz')   # => "luces"
   inflector.singularize('luces')   # => "luz"
   inflector.pluralize('ley')   # => "leyes"
   inflector.pluralize('avion') # => "aviones"
   inflector.pluralize('caja') # => "cajas"
```